### PR TITLE
Show bootstrap tooltip with full chat time.

### DIFF
--- a/public/js/bundle/jibe.js
+++ b/public/js/bundle/jibe.js
@@ -198,7 +198,7 @@ function Chat (data) {
       // on hover, display the full time in a bootstrap tooltip
       .data ('toggle', 'tooltip')
       .data ('placement', 'top')
-      .prop ('title', moment (message.timestamp, moment.ISO_8601).format ('MMMM Do YYYY, h:mm:ss a'))
+      .prop ('title', moment (message.timestamp).format ('MMMM Do YYYY, h:mm:ss a'))
       .tooltip ( { container: 'body' } );
 
     if (message.authorId == instance.client.id) {

--- a/public/js/bundle/jibe.js
+++ b/public/js/bundle/jibe.js
@@ -189,7 +189,17 @@ function Chat (data) {
     var classes = "chat-message";
     var userDiv;
 
-    var timeSpan = $('<span>').addClass('timeago').data('timestamp', message.timestamp).text(timeago(message.timestamp));
+    // create a new span to display the time the message was sent
+    var timeSpan = $('<span>')
+      // display the relative 'timeago' the message was sent
+      .addClass('timeago')
+      .text (timeago (message.timestamp))
+      .data ('timestamp', message.timestamp)
+      // on hover, display the full time in a bootstrap tooltip
+      .data ('toggle', 'tooltip')
+      .data ('placement', 'top')
+      .prop ('title', moment (message.timestamp, moment.ISO_8601).format ('MMMM Do YYYY, h:mm:ss a'))
+      .tooltip ( { container: 'body' } );
 
     if (message.authorId == instance.client.id) {
       classes += " bubble-mine animated bounceIn";

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -84,7 +84,7 @@ function Chat (data) {
       // on hover, display the full time in a bootstrap tooltip
       .data ('toggle', 'tooltip')
       .data ('placement', 'top')
-      .prop ('title', moment (message.timestamp, moment.ISO_8601).format ('MMMM Do YYYY, h:mm:ss a'))
+      .prop ('title', moment (message.timestamp).format ('MMMM Do YYYY, h:mm:ss a'))
       .tooltip ( { container: 'body' } );
 
     if (message.authorId == instance.client.id) {

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -75,7 +75,17 @@ function Chat (data) {
     var classes = "chat-message";
     var userDiv;
 
-    var timeSpan = $('<span>').addClass('timeago').data('timestamp', message.timestamp).text(timeago(message.timestamp));
+    // create a new span to display the time the message was sent
+    var timeSpan = $('<span>')
+      // display the relative 'timeago' the message was sent
+      .addClass('timeago')
+      .text (timeago (message.timestamp))
+      .data ('timestamp', message.timestamp)
+      // on hover, display the full time in a bootstrap tooltip
+      .data ('toggle', 'tooltip')
+      .data ('placement', 'top')
+      .prop ('title', moment (message.timestamp, moment.ISO_8601).format ('MMMM Do YYYY, h:mm:ss a'))
+      .tooltip ( { container: 'body' } );
 
     if (message.authorId == instance.client.id) {
       classes += " bubble-mine animated bounceIn";


### PR DESCRIPTION
When hovering over a timestamp in the chat log, display the full timestamp in a bootstrap tooltip.

Closes #64 .
