### PR TITLE
Simpler and more effective tooltip creation.

### DIFF
--- a/public/js/bundle/jibe.js
+++ b/public/js/bundle/jibe.js
@@ -1605,27 +1605,22 @@ function Timestamps (data) {
     }
 
     $(this.container).html (content);
-    this.activateTooltips ();
+    this.addTooltips ();
   };
 
   /*
-   *  Draws the timestamps into its given container.
+   *  For each timestamp in the container, add a tooltip to display
+   *  the author of the corresponding line on hover.
    */
-  this.activateTooltips = function () {
-    $('.timestamp')
-      .mouseenter (function () {
-        $(this).attr ('data-toggle', 'tooltip')
-               .attr ('data-placement', 'top')
-               .attr ('title', $(this).data ('author'));
-
-       $('[data-toggle="tooltip"]').tooltip ({
-         container: 'body'
-       });
-      })
-      .mouseleave (function () {
-        $(this).removeAttr ('data-toggle')
-               .removeAttr ('data-placement')
-               .removeAttr ('title');
+  this.addTooltips = function () {
+    $(this.container).find('.timestamp')
+      // on hover, display the full time in a bootstrap tooltip
+      .data ('toggle', 'tooltip')
+      .data ('placement', 'top')
+      .each (function () {
+        $(this)
+          .prop ('title', $(this).data ('author'))
+          .tooltip ( { container: 'body' } );
       });
   };
 }

--- a/public/js/bundle/jibe.js
+++ b/public/js/bundle/jibe.js
@@ -1614,7 +1614,7 @@ function Timestamps (data) {
    */
   this.addTooltips = function () {
     $(this.container).find('.timestamp')
-      // on hover, display the full time in a bootstrap tooltip
+      // on hover, display the author in a bootstrap tooltip
       .data ('toggle', 'tooltip')
       .data ('placement', 'top')
       .each (function () {

--- a/public/js/timestamps.js
+++ b/public/js/timestamps.js
@@ -99,27 +99,22 @@ function Timestamps (data) {
     }
 
     $(this.container).html (content);
-    this.activateTooltips ();
+    this.addTooltips ();
   };
 
   /*
-   *  Draws the timestamps into its given container.
+   *  For each timestamp in the container, add a tooltip to display
+   *  the author of the corresponding line on hover.
    */
-  this.activateTooltips = function () {
-    $('.timestamp')
-      .mouseenter (function () {
-        $(this).attr ('data-toggle', 'tooltip')
-               .attr ('data-placement', 'top')
-               .attr ('title', $(this).data ('author'));
-
-       $('[data-toggle="tooltip"]').tooltip ({
-         container: 'body'
-       });
-      })
-      .mouseleave (function () {
-        $(this).removeAttr ('data-toggle')
-               .removeAttr ('data-placement')
-               .removeAttr ('title');
+  this.addTooltips = function () {
+    $(this.container).find('.timestamp')
+      // on hover, display the full time in a bootstrap tooltip
+      .data ('toggle', 'tooltip')
+      .data ('placement', 'top')
+      .each (function () {
+        $(this)
+          .prop ('title', $(this).data ('author'))
+          .tooltip ( { container: 'body' } );
       });
   };
 }

--- a/public/js/timestamps.js
+++ b/public/js/timestamps.js
@@ -108,7 +108,7 @@ function Timestamps (data) {
    */
   this.addTooltips = function () {
     $(this.container).find('.timestamp')
-      // on hover, display the full time in a bootstrap tooltip
+      // on hover, display the author in a bootstrap tooltip
       .data ('toggle', 'tooltip')
       .data ('placement', 'top')
       .each (function () {


### PR DESCRIPTION
This modifies the way the tooltips are handled for the line metadata, to the left of the document text.  

Previously, on hover, we were adding the necessary data fields and initializing the tooltip functionality on mouseenter, and then removing them on mouseleave.  I think this was unnecessary, and resulted in the tooltips not always working, either; it didn't work on the initial hover many times.
