### PR TITLE
Properly handle text inserted via api calls.

### DIFF
--- a/public/js/share-codemirror-json.js
+++ b/public/js/share-codemirror-json.js
@@ -160,7 +160,15 @@
               timestamp: new Date ()
             }});
           } else {
-            if (change.origin !== 'paste' && change.origin !== 'redo' && change.origin !== 'undo') {
+            /*
+             *  For the following values of change.origin, we know what we want to happen.
+             *  - null - this is a programmatic insertion
+             *  - paste, redo, undo - cm detected the indicated behavior
+             *
+             *  For others, they'll have to fall through and be handled accordingly.
+             *  Not having this conditional here leads to things breaking...
+             */
+            if (change.origin && change.origin !== 'paste' && change.origin !== 'redo' && change.origin !== 'undo') {
               console.warn('not sure what to do in this case', change);
             } else {
 


### PR DESCRIPTION
Previously, inserting multiple lines with the insertTextAtCursor call was breaking the timestamps.  Now, handle this the same as if someone copy and pasted a block of text in, etc.

Fixes #68.
